### PR TITLE
Fixes SWC binary error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}


### PR DESCRIPTION
## ERROR:

#### What is the Error
* When cloning this repo on another machine the following error is created: 
* `error - Failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loading-swc`

### Fix
* Adding a `.babelrc` file with the following values:
```json 
{
  "presets": ["next/babel"]
}
```
